### PR TITLE
[Patch] Support GHC 9.0

### DIFF
--- a/Unsafe/TrueName.hs
+++ b/Unsafe/TrueName.hs
@@ -196,6 +196,9 @@ typNames typ = case typ of
 #if MIN_VERSION_template_haskell(2,16,0)
     ForallVisT _ t -> typNames t
 #endif
+#if MIN_VERSION_template_haskell(2,17,0)
+    MulArrowT -> []
+#endif
 {- }}} -}
 
 infoNames :: Info -> [Name]{- {{{ -}
@@ -232,7 +235,7 @@ infoNames info = case info of
 -- a list of 'Name's found, along with the output of 'reify' for reference.
 --
 -- Suppose we are given a module @M@ that exports a function @s@, but not
--- the type @T@, the constrcutor @C@, nor the field @f@:
+-- the type @T@, the constructor @C@, nor the field @f@:
 --
 -- > module M (s) where
 -- > newtype T = C { f :: Int }

--- a/true-name.cabal
+++ b/true-name.cabal
@@ -1,5 +1,5 @@
 name:           true-name
-version:        0.1.0.4
+version:        0.1.0.5
 synopsis:       Template Haskell hack to violate module abstractions
 description:
     <http://tvtropes.org/pmwiki/pmwiki.php/Main/IKnowYourTrueName Knowing a true name gives one power over its owner>.
@@ -16,7 +16,7 @@ license:        BSD3
 license-file:   LICENSE
 author:         Liyang HU
 maintainer:     true-name@liyang.hu
-copyright:      © 2014−2021 Liyang HU
+copyright:      © 2014−2024 Liyang HU
 category:       Data, Unsafe
 build-type:     Simple
 cabal-version:  >= 1.10
@@ -25,7 +25,8 @@ tested-with:
     GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3,
     GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5,
     GHC == 8.8.3,
-    GHC == 8.10.1
+    GHC == 8.10.1,
+    GHC == 9.0.2
 
 source-repository head
     type:       git


### PR DESCRIPTION
Hi @liyang !

Just found myself stumbling yet again over unexported constructors "issue" (a library had wrapped an STM primitive without a way to unwrap, breaking STM's composability I needed).

Here's a quick patch making the package compile with GHC 9.0. `cabal test` passes :heavy_check_mark: 
With 9.2 there's another issue, but for my case I found an alternative workaround.

Relatedly, did you see this hack? `importHidden` TH splice https://www.tweag.io/blog/2021-01-07-haskell-dark-arts-part-i/

It'd be easy to roll out as an alternative library, but pity to see such a well-rounded package not supporting latest GHC's!
